### PR TITLE
Ensure source directories chowned to target user

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -30,6 +30,7 @@ run_system_script() {
 
 PACKAGE_ARGS=("$@")
 run_system_script packages "${PACKAGE_ARGS[@]}"
+# Run swap_gpio ahead of fstab so user/group IDs are correct before chowning mounts.
 run_system_script swap_gpio
 run_system_script fstab
 

--- a/script/system/fstab.sh
+++ b/script/system/fstab.sh
@@ -3,6 +3,12 @@
 
 TARGET_USER="${SUDO_USER:-$USER}"
 TARGET_HOME="$(eval echo "~$TARGET_USER")"
+TARGET_GROUP="$(id -gn "$TARGET_USER")"
+
+if [[ -z "$TARGET_GROUP" ]]; then
+  echo "Unable to determine primary group for $TARGET_USER" >&2
+  exit 1
+fi
 
 SRC_SSH="/mnt/eapp/skel/.ssh"
 SRC_KUBE="/mnt/eapp/skel/.kube"
@@ -18,8 +24,10 @@ ensure_src_dir() {
     exit 1
   fi
   if [[ ! -d "$dir" ]]; then
-    install -d -m "$perm" "$dir"
+    install -d -m "$perm" -o "$TARGET_USER" -g "$TARGET_GROUP" "$dir"
   fi
+  chown "$TARGET_USER:$TARGET_GROUP" "$dir"
+  chmod "$perm" "$dir"
 }
 
 ensure_src_dir "$SRC_SSH" 700


### PR DESCRIPTION
## Summary
- look up the target user's primary group before running the fstab sync
- ensure the source directories are created and owned by the target user/group
- document that swap_gpio runs ahead of fstab so mounts inherit the corrected IDs

## Testing
- bash -n script/system/fstab.sh
- bash -n script/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d03e8c3d7c832cac148f0c67b20607